### PR TITLE
add 2.6 ms delay to piface_lcd_clear() and piface_lcd_home()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,3 +4,10 @@ Change Log
 v0.1.0
 ------
 - Initial release.
+v0.2.0
+------
+- ???
+v0.2.1
+------
+- add 2.6 ms delay to piface_lcd_clear() and piface_lcd_home()
+- change SEQOP_ON to SEQOP_OFF in piface_open_noinit() jw 2014/06/26

--- a/src/pifacecad.c
+++ b/src/pifacecad.c
@@ -43,7 +43,7 @@ int pifacecad_open(void)
     // Set IO config
     const uint8_t ioconfig = BANK_OFF | \
                              INT_MIRROR_OFF | \
-                             SEQOP_ON | \
+                             SEQOP_OFF | \
                              DISSLW_OFF | \
                              HAEN_ON | \
                              ODR_OFF | \
@@ -160,16 +160,37 @@ uint8_t pifacecad_lcd_get_cursor_address(void)
     return cur_address;
 }
 
+/********************************************************************
+ *  Modified 2014/06/26 John Wulff <immediatec@gmail.com>
+ *  2.6 ms delay after LCD_CLEARDISPLAY
+ *
+ *  Execution time of the "Clear display" command is not specified
+ *  in the HITACHI date sheet HD44780U, page 24. (Probably a misprint)
+ *  It was measured and found to be 1.6 to 2.4 ms +- 0.2 ms
+ *******************************************************************/
 
 void pifacecad_lcd_clear(void)
 {
     pifacecad_lcd_send_command(LCD_CLEARDISPLAY);
+    sleep_ns(DELAY_CLEAR_NS);		/* 2.6 ms  - added JW 2014/06/26 */
     cur_address = 0;
 }
+
+/********************************************************************
+ *  2.6 ms delay after LCD_RETURNHOME
+ *
+ *  Execution time of the "Return home" command is specified as 1.52 ms
+ *  in the HITACHI date sheet HD44780U, page 24. (Probably meant for
+ *  "Clear display")
+ *  It was measured and found to be less than 0.8 ms and is probably
+ *  37 us like all other commands.  To be safe the delay was added here
+ *  also as it hardly influences performance.
+ *******************************************************************/
 
 void pifacecad_lcd_home(void)
 {
     pifacecad_lcd_send_command(LCD_RETURNHOME);
+    sleep_ns(DELAY_CLEAR_NS);		/* 2.6 ms  - added JW 2014/06/26 */
     cur_address = 0;
 }
 

--- a/src/pifacecad.h
+++ b/src/pifacecad.h
@@ -3,6 +3,7 @@
  * @brief A simple static library for controlling PiFace Control and Display.
  *
  * Copyright (C) 2013 Thomas Preston <thomas.preston@openlx.org.uk>
+ * Modified 2014/06/26 John Wulff <immediatec@gmail.com> 2.6 ms delay after LCD_CLEARDISPLAY
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,6 +30,7 @@ extern "C" {
 
 #define DELAY_PULSE_NS 1000 // 1us
 #define DELAY_SETTLE_NS 40000 // 40us
+#define DELAY_CLEAR_NS 2600000L // 2.6ms
 #define DELAY_SETUP_0_NS 15000000L // 15ms
 #define DELAY_SETUP_1_NS 5000000L // 5ms
 #define DELAY_SETUP_2_NS 1000000L // 1ms


### PR DESCRIPTION
-  2.6 ms delay after LCD_CLEARDISPLAY
  *
-  Execution time of the "Clear display" command is not specified
-  in the HITACHI date sheet HD44780U, page 24. (Probably a misprint)
-  It was measured and found to be 1.6 to 2.4 ms +- 0.2 ms
-  2.6 ms delay after LCD_RETURNHOME
  *
-  Execution time of the "Return home" command is specified as 1.52 ms
-  in the HITACHI date sheet HD44780U, page 24. (Probably meant for
-  "Clear display")
-  It was measured and found to be less than 0.8 ms and is probably
-  37 us like all other commands.  To be safe the delay was added here
-  also as it hardly influences performance.

change SEQOP_ON to SEQOP_OFF in piface_open_noinit()

These values set bit 5 of the IOCON register in the MCP23S17 I/O Expander. Setting this bit to 0 (SEQOP_ON) enables address pointer increments in the MCP23S17. I do not think this is ever used (especially with BANK_OFF). Every command to the MCP23S17 sets a new address. The auto-incrementing of text byte transfers in the HD44780U is handled somewhere else.
