### PR TITLE
BUGFIX: right_to_left and left_to_eight

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,3 +11,28 @@ v0.2.1
 ------
 - add 2.6 ms delay to piface_lcd_clear() and piface_lcd_home()
 - change SEQOP_ON to SEQOP_OFF in piface_open_noinit() jw 2014/06/26
+------
+v0.2.2
+Date: 2018-02-08
+- pifacecad_lcd_right_to_left and pifacecad_lcd_autoscroll_off modified
+  cur_display_control instead of cur_entry_mode.
+
+- The descriptions of function in pifacecad.h had been copy and
+  pasted, but the function names was not updated in the examples.
+------
+v0.2.3
+Date: 2018-02-08
+- Added utility funcitons:
+  void pifacecad_lcd_display_control(uint8_t attr, uint8_t state);
+  void pifacecad_lcd_entry_mode(uint8_t attr, uint8_t state);
+
+- Added functions that take a parameter instead of having to call
+  two diffrerent functions for turning a thing on or off.
+
+  void pifacecad_lcd_display(uint8_t state)
+  void pifacecad_lcd_blink(uint8_t state)
+  void pifacecad_lcd_cursor(uint8_t state)
+  void pifacecad_lcd_autoscroll(uint8_t state)
+
+- Makefile distclean removes more files.
+------

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ $(BINARY): $(OBJECTS)
 	$(CC) $(INCFLAGS) $(CFLAGS) -fPIC $< -o $@
 
 distclean: clean
-	rm -f $(BINARY)
+	rm -f $(BINARY) example test
 
 clean:
 	rm -f $(OBJECTS)

--- a/src/pifacecad.c
+++ b/src/pifacecad.c
@@ -194,41 +194,49 @@ void pifacecad_lcd_home(void)
     cur_address = 0;
 }
 
+void pifacecad_lcd_display(uint8_t state)
+{
+  pifacecad_lcd_display_control( LCD_DISPLAYON, state );
+}
 
 void pifacecad_lcd_display_on(void)
 {
-    cur_display_control |= LCD_DISPLAYON;
-    pifacecad_lcd_send_command(LCD_DISPLAYCONTROL | cur_display_control);
+    pifacecad_lcd_display(1);
 }
 
 void pifacecad_lcd_display_off(void)
 {
-    cur_display_control &= 0xff ^ LCD_DISPLAYON;
-    pifacecad_lcd_send_command(LCD_DISPLAYCONTROL | cur_display_control);
+    pifacecad_lcd_display(0);
+}
+
+void pifacecad_lcd_blink(uint8_t state)
+{
+  pifacecad_lcd_display_control( LCD_BLINKON, state );
 }
 
 void pifacecad_lcd_blink_on(void)
 {
-    cur_display_control |= LCD_BLINKON;
-    pifacecad_lcd_send_command(LCD_DISPLAYCONTROL | cur_display_control);
+    pifacecad_lcd_blink(1);
 }
 
 void pifacecad_lcd_blink_off(void)
 {
-    cur_display_control &= 0xff ^ LCD_BLINKON;
-    pifacecad_lcd_send_command(LCD_DISPLAYCONTROL | cur_display_control);
+    pifacecad_lcd_blink(0);
+}
+
+void pifacecad_lcd_cursor(uint8_t state)
+{
+  pifacecad_lcd_display_control( LCD_CURSORON, state );
 }
 
 void pifacecad_lcd_cursor_on(void)
 {
-    cur_display_control |= LCD_CURSORON;
-    pifacecad_lcd_send_command(LCD_DISPLAYCONTROL | cur_display_control);
+    pifacecad_lcd_cursor(1);
 }
 
 void pifacecad_lcd_cursor_off(void)
 {
-    cur_display_control &= 0xff ^ LCD_CURSORON;
-    pifacecad_lcd_send_command(LCD_DISPLAYCONTROL | cur_display_control);
+    pifacecad_lcd_cursor(0);
 }
 
 void pifacecad_lcd_backlight_on(void)
@@ -257,28 +265,29 @@ void pifacecad_lcd_move_right(void)
 
 void pifacecad_lcd_left_to_right(void)
 {
-    cur_entry_mode |= LCD_ENTRYLEFT;
-    pifacecad_lcd_send_command(LCD_ENTRYMODESET | cur_entry_mode);
+    pifacecad_lcd_entry_mode( LCD_ENTRYLEFT, 1 );
 }
 
 void pifacecad_lcd_right_to_left(void)
 {
-    cur_entry_mode &= 0xff ^ LCD_ENTRYLEFT;
-    pifacecad_lcd_send_command(LCD_ENTRYMODESET | cur_entry_mode);
+    pifacecad_lcd_entry_mode( LCD_ENTRYLEFT, 0 );
+}
+
+void pifacecad_lcd_autoscroll(uint8_t state)
+{
+    pifacecad_lcd_entry_mode( LCD_ENTRYSHIFTINCREMENT, state );
 }
 
 // This will 'right justify' text from the cursor
 void pifacecad_lcd_autoscroll_on(void)
 {
-    cur_entry_mode |= LCD_ENTRYSHIFTINCREMENT;
-    pifacecad_lcd_send_command(LCD_ENTRYMODESET | cur_entry_mode);
+    pifacecad_lcd_autoscroll(1);
 }
 
 // This will 'left justify' text from the cursor
 void pifacecad_lcd_autoscroll_off(void)
 {
-    cur_entry_mode &= 0xff ^ LCD_ENTRYSHIFTINCREMENT;
-    pifacecad_lcd_send_command(LCD_ENTRYMODESET | cur_entry_mode);
+    pifacecad_lcd_autoscroll(0);
 }
 
 void pifacecad_lcd_write_custom_bitmap(uint8_t location)
@@ -296,6 +305,24 @@ void pifacecad_lcd_store_custom_bitmap(uint8_t location, uint8_t bitmap[])
     for (i = 0; i < 8; i++) {
         pifacecad_lcd_send_data(bitmap[i]);
     }
+}
+
+void pifacecad_lcd_display_control(uint8_t attr, uint8_t state)
+{
+    if ( state )
+      cur_display_control |= attr;
+    else
+      cur_display_control &= 0xff ^ attr;
+    pifacecad_lcd_send_command(LCD_DISPLAYCONTROL | cur_display_control);
+}
+
+void pifacecad_lcd_entry_mode(uint8_t attr, uint8_t state)
+{
+    if ( state )
+      cur_entry_mode |= attr;
+    else
+      cur_entry_mode &= 0xff ^ attr;
+    pifacecad_lcd_send_command(LCD_ENTRYMODESET | cur_entry_mode);
 }
 
 void pifacecad_lcd_send_command(uint8_t command)

--- a/src/pifacecad.c
+++ b/src/pifacecad.c
@@ -270,15 +270,15 @@ void pifacecad_lcd_right_to_left(void)
 // This will 'right justify' text from the cursor
 void pifacecad_lcd_autoscroll_on(void)
 {
-    cur_display_control |= LCD_ENTRYSHIFTINCREMENT;
-    pifacecad_lcd_send_command(LCD_ENTRYMODESET | cur_display_control);
+    cur_entry_mode |= LCD_ENTRYSHIFTINCREMENT;
+    pifacecad_lcd_send_command(LCD_ENTRYMODESET | cur_entry_mode);
 }
 
 // This will 'left justify' text from the cursor
 void pifacecad_lcd_autoscroll_off(void)
 {
-    cur_display_control &= 0xff ^ LCD_ENTRYSHIFTINCREMENT;
-    pifacecad_lcd_send_command(LCD_ENTRYMODESET | cur_display_control);
+    cur_entry_mode &= 0xff ^ LCD_ENTRYSHIFTINCREMENT;
+    pifacecad_lcd_send_command(LCD_ENTRYMODESET | cur_entry_mode);
 }
 
 void pifacecad_lcd_write_custom_bitmap(uint8_t location)

--- a/src/pifacecad.h
+++ b/src/pifacecad.h
@@ -222,6 +222,16 @@ void pifacecad_lcd_clear(void);
 void pifacecad_lcd_home(void);
 
 /**
+ * Turns the display on or off.
+ *
+ * Example:
+ *
+ *     pifacecad_lcd_display(1);
+ *
+ */
+void pifacecad_lcd_display(uint8_t state);
+
+/**
  * Turns the display on.
  *
  * Example:
@@ -242,6 +252,16 @@ void pifacecad_lcd_display_on(void);
 void pifacecad_lcd_display_off(void);
 
 /**
+ * Turns the blinking cursor on or off.
+ *
+ * Example:
+ *
+ *     pifacecad_lcd_blink(1);
+ *
+ */
+void pifacecad_lcd_blink(uint8_t state);
+
+/**
  * Turns the blink on.
  *
  * Example:
@@ -260,6 +280,16 @@ void pifacecad_lcd_blink_on(void);
  *
  */
 void pifacecad_lcd_blink_off(void);
+
+/**
+ * Turns the underline cursor on or off
+ *
+ * Example:
+ *
+ *     pifacecad_lcd_cursor(1);
+ *
+ */
+void pifacecad_lcd_cursor(uint8_t state);
 
 /**
  * Turns the cursor on.
@@ -342,6 +372,16 @@ void pifacecad_lcd_left_to_right(void);
  *
  */
 void pifacecad_lcd_right_to_left(void);
+
+/**
+ * The screen will follow text if it moves out of view.
+ *
+ * Example:
+ *
+ *     pifacecad_lcd_autoscroll(1);
+ *
+ */
+void pifacecad_lcd_autoscroll(uint8_t state);
 
 /**
  * The screen will follow text if it moves out of view.
@@ -498,6 +538,9 @@ uint8_t address2row(uint8_t address);
 
 // int pifacecad_lcd_set_viewport_corner(int col);
 // int pifacecad_lcd_see_cursor(int col);
+
+void pifacecad_lcd_display_control(uint8_t attr, uint8_t state);
+void pifacecad_lcd_entry_mode(uint8_t attr, uint8_t state);
 
 #ifdef __cplusplus
 }

--- a/src/pifacecad.h
+++ b/src/pifacecad.h
@@ -246,7 +246,7 @@ void pifacecad_lcd_display_off(void);
  *
  * Example:
  *
- *     pifacecad_lcd_display_on();
+ *     pifacecad_lcd_blink_on();
  *
  */
 void pifacecad_lcd_blink_on(void);
@@ -256,7 +256,7 @@ void pifacecad_lcd_blink_on(void);
  *
  * Example:
  *
- *     pifacecad_lcd_display_off();
+ *     pifacecad_lcd_blink_off();
  *
  */
 void pifacecad_lcd_blink_off(void);
@@ -266,7 +266,7 @@ void pifacecad_lcd_blink_off(void);
  *
  * Example:
  *
- *     pifacecad_lcd_display_on();
+ *     pifacecad_lcd_cursor_on();
  *
  */
 void pifacecad_lcd_cursor_on(void);
@@ -276,7 +276,7 @@ void pifacecad_lcd_cursor_on(void);
  *
  * Example:
  *
- *     pifacecad_lcd_display_off();
+ *     pifacecad_lcd_cursor_off();
  *
  */
 void pifacecad_lcd_cursor_off(void);
@@ -286,7 +286,7 @@ void pifacecad_lcd_cursor_off(void);
  *
  * Example:
  *
- *     pifacecad_lcd_display_on();
+ *     pifacecad_lcd_backlight_on();
  *
  */
 void pifacecad_lcd_backlight_on(void);
@@ -296,7 +296,7 @@ void pifacecad_lcd_backlight_on(void);
  *
  * Example:
  *
- *     pifacecad_lcd_display_off();
+ *     pifacecad_lcd_backlight_off();
  *
  */
 void pifacecad_lcd_backlight_off(void);

--- a/src/pifacecad.h
+++ b/src/pifacecad.h
@@ -88,7 +88,7 @@ extern "C" {
 #define LCD_WIDTH 16
 #define LCD_RAM_WIDTH 80 // RAM is 80 wide, split over two lines
 
-static const uint8_t ROW_OFFSETS[] = {0, 0x40};
+static const uint8_t ROW_OFFSETS[] = {0, 40}; // Second row is at decimal 40.
 
 /**
  * Opens and initialises a PiFace Control and Display.


### PR DESCRIPTION
* pifacecad_lcd_right_to_left and pifacecad_lcd_autoscroll_off modified
  cur_display_control instead of cur_entry_mode.

* The descriptions of function in pifacecad.h had been copy and
  pasted, but the function names was not updated in the examples.

pifacecad.c

void pifacecad_lcd_right_to_left(void)
 // This will 'right justify' text from the cursor
 void pifacecad_lcd_autoscroll_on(void)
 {
-    cur_display_control |= LCD_ENTRYSHIFTINCREMENT;
-    pifacecad_lcd_send_command(LCD_ENTRYMODESET | cur_display_control);
+    cur_entry_mode |= LCD_ENTRYSHIFTINCREMENT;
+    pifacecad_lcd_send_command(LCD_ENTRYMODESET | cur_entry_mode);
 }

 // This will 'left justify' text from the cursor
 void pifacecad_lcd_autoscroll_off(void)
 {
-    cur_display_control &= 0xff ^ LCD_ENTRYSHIFTINCREMENT;
-    pifacecad_lcd_send_command(LCD_ENTRYMODESET | cur_display_control);
+    cur_entry_mode &= 0xff ^ LCD_ENTRYSHIFTINCREMENT;
+    pifacecad_lcd_send_command(LCD_ENTRYMODESET | cur_entry_mode);
 }

pifacecad.h

- *     pifacecad_lcd_display_on();
+ *     pifacecad_lcd_blink_on();

- *     pifacecad_lcd_display_off();
+ *     pifacecad_lcd_blink_off();

- *     pifacecad_lcd_display_on();
+ *     pifacecad_lcd_cursor_on();

- *     pifacecad_lcd_display_off();
+ *     pifacecad_lcd_cursor_off();

- *     pifacecad_lcd_display_on();
+ *     pifacecad_lcd_backlight_on();

- *     pifacecad_lcd_display_off();
+ *     pifacecad_lcd_backlight_off();